### PR TITLE
Create database entities to store chat history

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,10 @@
   "jvm_version": "21",
   "build_system": "gradle-kotlin",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "com.example.llmchat.model.RoleTest",
+      "com.example.llmchat.repository.ChatPersistenceTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 extra["springAiVersion"] = "1.0.1"
 
 dependencies {
+	implementation ("org.springframework.ai:spring-ai-starter-model-openai")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
 	implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 	implementation("org.springframework.boot:spring-boot-starter-web")
@@ -30,9 +31,13 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.springframework.ai:spring-ai-starter-model-ollama")
     runtimeOnly("org.postgresql:postgresql")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+	testImplementation("org.testcontainers:junit-jupiter:1.20.4")
+	testImplementation("org.testcontainers:postgresql:1.20.4")
+	testImplementation("com.h2database:h2")
 }
 
 dependencyManagement {

--- a/src/main/kotlin/com/example/llmchat/model/Chat.kt
+++ b/src/main/kotlin/com/example/llmchat/model/Chat.kt
@@ -1,0 +1,22 @@
+package com.example.llmchat.model
+
+import jakarta.persistence.*
+import java.time.Instant
+
+@Entity
+@Table(name = "chat")
+class Chat (
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Column(name = "title", nullable = false)
+    var title: String = "",
+
+    @Column(name = "createdAt", updatable = false, nullable = false)
+    var createdAt: Instant = Instant.now(),
+
+    @Column(name = "history")
+    @OneToMany(cascade = [CascadeType.ALL], mappedBy = "chat", fetch = FetchType.EAGER)
+    var history: MutableList<ChatEntity> = mutableListOf(),
+)

--- a/src/main/kotlin/com/example/llmchat/model/ChatEntity.kt
+++ b/src/main/kotlin/com/example/llmchat/model/ChatEntity.kt
@@ -1,0 +1,34 @@
+package com.example.llmchat.model
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.Instant
+
+@Entity
+@Table(name = "chat_entity")
+class ChatEntity(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    var id: Long? = null,
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role")
+    var role: Role,
+
+    @Column(name = "createdAt")
+    var createdAt: Instant = Instant.now(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "chat_id")
+    val chat: Chat
+)

--- a/src/main/kotlin/com/example/llmchat/model/Role.kt
+++ b/src/main/kotlin/com/example/llmchat/model/Role.kt
@@ -1,0 +1,23 @@
+package com.example.llmchat.model
+
+import com.fasterxml.jackson.annotation.JsonIgnore
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.Message
+import org.springframework.ai.chat.messages.SystemMessage
+import org.springframework.ai.chat.messages.UserMessage
+
+enum class Role(private val displayName: String) {
+
+    USER("user") {
+        override fun getMessage(prompt: String): Message = UserMessage(prompt)
+    },
+    ASSISTANT("assistant") {
+        override fun getMessage(prompt: String): Message = AssistantMessage(prompt)
+    },
+    SYSTEM("system") {
+        override fun getMessage(prompt: String): Message = SystemMessage(prompt)
+    };
+
+    @JsonIgnore
+    abstract fun getMessage(prompt: String): Message
+}

--- a/src/main/kotlin/com/example/llmchat/repository/ChatRepository.kt
+++ b/src/main/kotlin/com/example/llmchat/repository/ChatRepository.kt
@@ -1,0 +1,6 @@
+package com.example.llmchat.repository
+
+import com.example.llmchat.model.Chat
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ChatRepository : JpaRepository<Chat, Long>

--- a/src/test/kotlin/com/example/llmchat/LlmChatExampleApplicationTests.kt
+++ b/src/test/kotlin/com/example/llmchat/LlmChatExampleApplicationTests.kt
@@ -2,7 +2,13 @@ package com.example.llmchat
 
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
 
+@Testcontainers
 @SpringBootTest
 class LlmChatExampleApplicationTests {
 
@@ -10,4 +16,25 @@ class LlmChatExampleApplicationTests {
 	fun contextLoads() {
 	}
 
+	companion object {
+		@Container
+		val postgres = PostgreSQLContainer("postgres:16-alpine")
+			.withDatabaseName("testdb")
+			.withUsername("test")
+			.withPassword("test")
+
+		@JvmStatic
+		@DynamicPropertySource
+		fun props(registry: DynamicPropertyRegistry) {
+			registry.add("spring.datasource.url", postgres::getJdbcUrl)
+			registry.add("spring.datasource.username", postgres::getUsername)
+			registry.add("spring.datasource.password", postgres::getPassword)
+			registry.add("spring.datasource.driver-class-name") { "org.postgresql.Driver" }
+			registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+			// because  as per gradle config both openAI and ollama models are automatically available model should
+			// be specified to avoid ambiguity
+			registry.add("spring.ai.model.chat") { "ollama" }
+			registry.add("spring.ai.openai.api-key") { "dummy" }
+		}
+	}
 }

--- a/src/test/kotlin/com/example/llmchat/model/RoleTest.kt
+++ b/src/test/kotlin/com/example/llmchat/model/RoleTest.kt
@@ -1,0 +1,32 @@
+package com.example.llmchat.model
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertInstanceOf
+import org.springframework.ai.chat.messages.AssistantMessage
+import org.springframework.ai.chat.messages.SystemMessage
+import org.springframework.ai.chat.messages.UserMessage
+
+class RoleTest {
+
+    @Test
+    fun whenGetMessageIsCalledForUserRoleThenUserMessageIsReturned() {
+        val result = Role.USER.getMessage(TEST_PROMPT)
+        assertInstanceOf<UserMessage>(result)
+    }
+
+    @Test
+    fun whenGetMessageIsCalledForAssistantRoleThenAssistantMessageIsReturned() {
+        val result = Role.ASSISTANT.getMessage(TEST_PROMPT)
+        assertInstanceOf<AssistantMessage>(result)
+    }
+
+    @Test
+    fun whenGetMessageIsCalledForSystemRoleThenSystemMessageIsReturned() {
+        val result = Role.SYSTEM.getMessage(TEST_PROMPT)
+        assertInstanceOf<SystemMessage>(result)
+    }
+
+    private companion object {
+        const val TEST_PROMPT = "test_prompt"
+    }
+}

--- a/src/test/kotlin/com/example/llmchat/repository/ChatPersistenceTest.kt
+++ b/src/test/kotlin/com/example/llmchat/repository/ChatPersistenceTest.kt
@@ -1,0 +1,60 @@
+package com.example.llmchat.repository
+
+import com.example.llmchat.model.Chat
+import com.example.llmchat.model.ChatEntity
+import com.example.llmchat.model.Role
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertNotNull
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.time.Instant
+import kotlin.test.assertEquals
+
+@Testcontainers
+@SpringBootTest
+class ChatPersistenceTest @Autowired constructor(
+    val repository: ChatRepository
+) {
+
+    @Test
+    fun whenCorrectDataPassedThenItIsPersistedCorrectly() {
+        val chat = Chat(title = "first_chat")
+        chat.history.add(ChatEntity(role = Role.USER, createdAt = Instant.now(), chat = chat))
+        chat.history.add(ChatEntity(role = Role.ASSISTANT, createdAt = Instant.now(), chat = chat))
+
+        val savedChat = repository.saveAndFlush(chat)
+        assertNotNull(savedChat.id)
+        val chatFromDB = repository.findById(savedChat.id!!).get()
+
+        assertEquals(2, chatFromDB.history.size)
+        assertEquals(Role.USER, chatFromDB.history[0].role)
+        assertEquals(Role.ASSISTANT, chatFromDB.history[1].role)
+    }
+
+    companion object {
+        @Container
+        val postgres = PostgreSQLContainer("postgres:16-alpine")
+            .withDatabaseName("testdb")
+            .withUsername("test")
+            .withPassword("test")
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun props(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgres::getJdbcUrl)
+            registry.add("spring.datasource.username", postgres::getUsername)
+            registry.add("spring.datasource.password", postgres::getPassword)
+            registry.add("spring.datasource.driver-class-name") { "org.postgresql.Driver" }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "create-drop" }
+            // because  as per gradle config both openAI and ollama models are automatically available model should
+            // be specified to avoid ambiguity
+            registry.add("spring.ai.model.chat") { "ollama" }
+            registry.add("spring.ai.openai.api-key") { "dummy" }
+        }
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.url=jdbc:h2:mem:llm-chat-test;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.ai.ollama.base-url=http://localhost:11431
+spring.ai.ollama.chat.model=test-model


### PR DESCRIPTION
Create the next hibernate entities:
1. Chat(id, title, createAt, history (which contains all chatEntities)
2. ChatEntity(id, role,createdAt)

Role is enum with the next possible values (user, assistant, system). Each enum should have the name and implement method abstract fun getMessage(prompt: String): Message, where message from org.springframework.ai.chat.messages
